### PR TITLE
Enable automatic german translation

### DIFF
--- a/config.tex
+++ b/config.tex
@@ -9,6 +9,7 @@
 % PACKAGES
 \usepackage[utf8]{inputenc} % Ermöglicht Umlaute usw...
 \usepackage[ngerman]{babel} % Deutsch-Support
+\usepackage[ngerman]{translator}
 \usepackage{makeidx} % Benötigt man für das Inhaltsverzeichnis
 \usepackage{hyperref} % Ermöglicht Hyperlinks
 \usepackage{tabularx} % Wird benötig um Tabellen zu erstellen

--- a/main.tex
+++ b/main.tex
@@ -2,7 +2,7 @@
 
 % IPA Dokumentation - Template
 
-\documentclass[a4paper,11pt,oneside]{report} % Lege Grundeigenschaften des Dokuments fest
+\documentclass[a4paper,11pt,oneside,ngerman]{report} % Lege Grundeigenschaften des Dokuments fest
 
 \input{config}
 


### PR DESCRIPTION
Enable automatic german translation if packages support it. I needed it for german week names when using `\pgfcalendar`, but there are probably more packages that use it.
